### PR TITLE
Fix warning on install if CiviRules is not enabled

### DIFF
--- a/CRM/Groupprotect/CiviRulesActions/actions.mgd.php
+++ b/CRM/Groupprotect/CiviRulesActions/actions.mgd.php
@@ -34,3 +34,6 @@ if (_groupprotect_is_civirules_installed()) {
       ),
   );
 }
+else {
+  return array();
+}


### PR DESCRIPTION
Fix for issue #5 