### PR TITLE
support Civi 5.x; support multisite

### DIFF
--- a/CRM/Groupprotect/BAO/GroupProtect.php
+++ b/CRM/Groupprotect/BAO/GroupProtect.php
@@ -36,15 +36,13 @@ class CRM_Groupprotect_BAO_GroupProtect {
    */
   public static function alterTemplateFile($formName, &$form, $context, &$tplName) {
     if ($formName == "CRM_Contact_Page_View_GroupContact") {
-      $domainVersion = civicrm_api3('Domain', 'getvalue', array('return' => 'version'));
+      $domainVersion = civicrm_api3('System', 'getvalue', array('return' => 'version'));
       $version = substr($domainVersion,0,3);
-      switch ($version) {
-        case '4.6':
-          $tplName = 'GroupContact46.tpl';
-          break;
-        case '4.7':
-          $tplName = 'GroupContact47.tpl';
-          break;
+      if ($version == 4.6) {
+        $tplName = 'GroupContact46.tpl';
+      }
+      else {
+        $tplName = 'GroupContact47.tpl';
       }
     }
 


### PR DESCRIPTION
There's two fixes here; I could separate them into separate PRs but they're somewhat intertwined.

The first one gets the `$domainVersion` using the System rather than Domain API.  The Domain API call fails in a multisite configuration with an error of "Expected one Domain but returned X", X being the number of domains you have.

The second change simply acknowledges that the template being replaced hasn't changed since 2015, so the 4.7 template can be used on 5.x.