### PR TITLE
Check if form element "group_id" exists before attempting to access it

### DIFF
--- a/CRM/Groupprotect/BAO/GroupProtect.php
+++ b/CRM/Groupprotect/BAO/GroupProtect.php
@@ -102,17 +102,19 @@ class CRM_Groupprotect_BAO_GroupProtect {
   /**
    * Method to remove protected groups from option lists
    *
-   * @param $form
+   * @param CRM_Core_Form $form
    * @access private
    * @static
    */
   private static function removeProtectedGroups(&$form) {
-    $groupElement = $form->getElement('group_id');
-    $options = &$groupElement->_options;
-    foreach ($options as $optionId => $optionValues) {
-      if (!empty($optionValues['attr']['value'])) {
-        if (self::groupIsProtected($optionValues['attr']['value']) == TRUE) {
-          unset($options[$optionId]);
+    if ($form->elementExists('group_id')) {
+      $groupElement = $form->getElement('group_id');
+      $options = &$groupElement->_options;
+      foreach ($options as $optionId => $optionValues) {
+        if (!empty($optionValues['attr']['value'])) {
+          if (self::groupIsProtected($optionValues['attr']['value']) == TRUE) {
+            unset($options[$optionId]);
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #6.

Might also fix #9, but not tested.

The element `group_id` does not always exist within the forms, thus checking its existence prior to attempting to access it avoids errors being thrown.

I'm not sure in which conditions the field is not there, I guess it depends on permissions the current user has for viewing groups/contacts or whether there exists a group to assign the contact being viewed or not.