### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">http://www.civicoop.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
- <releaseDate>2025-08-11</releaseDate>
+  <releaseDate>2025-08-11</releaseDate>
   <version>2.6</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.27</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>Extension is being tested</comments>
   <civix>

--- a/templates/GroupContact46.tpl
+++ b/templates/GroupContact46.tpl
@@ -70,9 +70,9 @@
             <td>{$row.in_date|crmDate}</td>
             <td>
               {if $permission EQ 'edit' and $actionItemsAllowed}
-                <a class="action-item crm-hover-button" href="#Removed" title={ts 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
+                <a class="action-item crm-hover-button" href="#Removed" title={ts escape='htmlattribute' 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
                   {ts}Remove{/ts}</a>
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (remove contact AND delete their record of having been in this group).{/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2? (remove contact AND delete their record of having been in this group).{/ts}">
                   {ts}Delete{/ts}</a>
               {/if}
             </td>
@@ -131,9 +131,9 @@
                 {/if}
               {/foreach}
               {if $permission EQ 'edit' AND $actionItemsAllowed}
-                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
+                <a class="action-item crm-hover-button" href="#Removed" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
                   {ts}Remove{/ts}</a>
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Pending Groups){/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Pending Groups){/ts}">
                   {ts}Delete{/ts}</a>
               {/if}
             </td>
@@ -177,9 +177,9 @@
             {/foreach}
             <td>
             {if $permission EQ 'edit' AND $actionItemsAllowed}
-                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
+                <a class="action-item crm-hover-button" href="#Added" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
                   {ts}Rejoin Group{/ts}</a>
-              <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Past Groups).{/ts}">
+              <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Past Groups).{/ts}">
                 {ts}Delete{/ts}</a>{/if}
             </td>
           </tr>

--- a/templates/GroupContact47.tpl
+++ b/templates/GroupContact47.tpl
@@ -70,9 +70,9 @@
             <td>{$row.in_date|crmDate}</td>
             <td>
               {if $permission EQ 'edit' AND $actionItemsAllowed}
-                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
+                <a class="action-item crm-hover-button" href="#Removed" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
                   {ts}Remove{/ts}</a>
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (remove contact AND delete their record of having been in this group).{/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2? (remove contact AND delete their record of having been in this group).{/ts}">
                   {ts}Delete{/ts}</a>
               {/if}
             </td>
@@ -131,9 +131,9 @@
             <td>{$row.pending_date|crmDate}</td>
             <td>
               {if $permission EQ 'edit' AND $actionItemsAllowed}
-                <a class="action-item crm-hover-button" href="#Removed" title="{ts 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
+                <a class="action-item crm-hover-button" href="#Removed" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Remove %1 from %2? (status in this group will be changed to 'Removed').{/ts}">
                   {ts}Remove{/ts}</a>
-                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Pending Groups){/ts}">
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Pending Groups){/ts}">
                   {ts}Delete{/ts}</a>
               {/if}
             </td>
@@ -177,9 +177,9 @@
             <td data-order="{$row.out_date}">{$row.out_date|crmDate}</td>
             <td>
             {if $permission EQ 'edit' AND $actionItemsAllowed}
-                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
+                <a class="action-item crm-hover-button" href="#Added" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
                   {ts}Rejoin Group{/ts}</a>
-              <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Past Groups).{/ts}">
+              <a class="action-item crm-hover-button" href="#Deleted" title="{ts escape='htmlattribute' 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Past Groups).{/ts}">
                 {ts}Delete{/ts}</a>{/if}
             </td>
           </tr>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.